### PR TITLE
feat: show game time like on OGS

### DIFF
--- a/app/src/main/java/io/zenandroid/onlinego/utils/Globals.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/utils/Globals.kt
@@ -174,6 +174,8 @@ fun computeTimeLeft(
 
 fun formatMillis(millis: Long): String {
     var seconds = ceil((millis - 1) / 1000.0).toLong()
+    val weeks = seconds / 604_800
+    seconds -= weeks * 604_800
     val days = seconds / 86_400
     seconds -= days * 86_400
     val hours = seconds / 3_600
@@ -182,8 +184,11 @@ fun formatMillis(millis: Long): String {
     seconds -= minutes * 60
 
     return when {
-        days >= 7 -> "%d week%s".format(days / 7, plural(days / 7))
-        days > 0 -> "%d day%s".format(days, plural(days))
+        weeks > 0 && days > 0 -> "%d week%s %d day%s".format(weeks, plural(weeks), days, plural(days))
+        weeks > 0 -> "%d week%s".format(weeks, plural(weeks))
+        days >= 2 && hours > 0 -> "%d day%s %d hour%s".format(days, plural(days), hours, plural(hours))
+        days > 2 -> "%d day%s".format(days, plural(days))
+        days > 0 -> "%dh".format(days * 24 + hours)
         hours > 0 -> "%dh %02dm".format(hours, minutes)
         minutes > 0 -> "%d : %02d".format(minutes, seconds)
         seconds > 10 -> "%02ds".format(seconds)

--- a/app/src/test/java/io/zenandroid/onlinego/ui/screens/game/GamePresenterTest.kt
+++ b/app/src/test/java/io/zenandroid/onlinego/ui/screens/game/GamePresenterTest.kt
@@ -54,12 +54,13 @@ class GamePresenterTest {
         assertEquals("1h 59m", formatMillis(1 * HOURS + 59 * MINUTES + 59 * SECONDS))
         assertEquals("2h 00m", formatMillis(2 * HOURS + 0 * MINUTES))
         assertEquals("23h 59m", formatMillis(23 * HOURS + 59 * MINUTES + 59 * SECONDS))
-        assertEquals("1 day", formatMillis(1 * DAYS))
-        assertEquals("1 day", formatMillis(1 * DAYS + 23 * HOURS + 59 * MINUTES))
-        assertEquals("2 days", formatMillis(2 * DAYS))
-        assertEquals("6 days", formatMillis(6 * DAYS + 23 * HOURS + 59 * MINUTES))
+        assertEquals("24h", formatMillis(1 * DAYS))
+        assertEquals("47h", formatMillis(1 * DAYS + 23 * HOURS + 59 * MINUTES))
+        assertEquals("48h", formatMillis(2 * DAYS))
+        assertEquals("3 days", formatMillis(3 * DAYS))
+        assertEquals("6 days 23 hours", formatMillis(6 * DAYS + 23 * HOURS + 59 * MINUTES))
         assertEquals("1 week", formatMillis(1 * WEEKS))
-        assertEquals("1 week", formatMillis(1 * WEEKS + 6 * DAYS + 23 * HOURS))
+        assertEquals("1 week 6 days", formatMillis(1 * WEEKS + 6 * DAYS + 23 * HOURS))
         assertEquals("2 weeks", formatMillis(2 * WEEKS))
     }
 }


### PR DESCRIPTION
Resolves #72

Simulation of time displayed on OGS.

Examples of time values with these new changes :

```
23h 59m
24h
25h
47h
48h
2 day 1 hour
2 day 23 hours
3 days
3 days 1 hour
6 days 23 hours
1 week
1 week 1 day
3 weeks 6 days
4 weeks
```