### PR TITLE
Correct bug not showing "?" when the user is on calibration matches

### DIFF
--- a/app/schemas/io.zenandroid.onlinego.data.db.Database/16.json
+++ b/app/schemas/io.zenandroid.onlinego.data.db.Database/16.json
@@ -1,12 +1,12 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 16,
-    "identityHash": "41f6abdc35160a31be9309553c5cdbd5",
+    "version": 17,
+    "identityHash": "008c05148fea65140819152f75476c79",
     "entities": [
       {
         "tableName": "Game",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `playerToMoveId` INTEGER, `outcome` TEXT, `whiteLost` INTEGER, `blackLost` INTEGER, `whiteGoesFirst` INTEGER, `moves` TEXT, `removedStones` TEXT, `phase` TEXT, `komi` REAL, `ended` INTEGER, `freeHandicapPlacement` INTEGER, `handicap` INTEGER, `undoRequested` INTEGER, `scoreAGAHandicap` INTEGER, `scoreHandicap` INTEGER, `scorePasses` INTEGER, `scorePrisoners` INTEGER, `scoreStones` INTEGER, `scoreTerritory` INTEGER, `scoreTerritoryInSeki` INTEGER, `name` TEXT, `rules` TEXT, `ranked` INTEGER, `disableAnalysis` INTEGER, `pausedSince` INTEGER, `messagesCount` INTEGER, `initial_state_black` TEXT, `initial_state_white` TEXT, `white_handicap` INTEGER, `white_komi` REAL, `white_prisoners` INTEGER, `white_scoring_positions` TEXT, `white_stones` INTEGER, `white_territory` INTEGER, `white_total` REAL, `black_handicap` INTEGER, `black_komi` REAL, `black_prisoners` INTEGER, `black_scoring_positions` TEXT, `black_stones` INTEGER, `black_territory` INTEGER, `black_total` REAL, `white_id` INTEGER NOT NULL, `white_username` TEXT NOT NULL, `white_rating` REAL, `white_historicRating` REAL, `white_country` TEXT, `white_icon` TEXT, `white_acceptedStones` TEXT, `white_ui_class` TEXT, `black_id` INTEGER NOT NULL, `black_username` TEXT NOT NULL, `black_rating` REAL, `black_historicRating` REAL, `black_country` TEXT, `black_icon` TEXT, `black_acceptedStones` TEXT, `black_ui_class` TEXT, `lastMove` INTEGER, `expiration` INTEGER, `now` INTEGER, `receivedAt` INTEGER, `whiteTimeSimple` INTEGER, `blackTimeSimple` INTEGER, `newPausedSince` INTEGER, `newPausedState` INTEGER, `startMode` INTEGER, `white_thinking_time` REAL, `white_skip_bonus` INTEGER, `white_block_time` REAL, `white_periods` INTEGER, `white_period_time` REAL, `white_moves_left` INTEGER, `black_thinking_time` REAL, `black_skip_bonus` INTEGER, `black_block_time` REAL, `black_periods` INTEGER, `black_period_time` REAL, `black_moves_left` INTEGER, `initial_state_system` TEXT, `initial_state_pause_on_weekends` INTEGER, `initial_state_time_control` TEXT, `initial_state_initial_time` INTEGER, `initial_state_max_time` INTEGER, `initial_state_time_increment` INTEGER, `initial_state_speed` TEXT, `initial_state_per_move` INTEGER, `initial_state_main_time` INTEGER, `initial_state_periods` INTEGER, `initial_state_period_time` INTEGER, `initial_state_stones_per_period` INTEGER, `initial_state_total_time` INTEGER, `pause_vacationWhite` INTEGER, `pause_vacationBlack` INTEGER, `pause_weekend` INTEGER, `pause_stoneRemoval` INTEGER, `pause_server` INTEGER, `pause_moderator` INTEGER, `pause_pausedByThirdParty` INTEGER, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `playerToMoveId` INTEGER, `outcome` TEXT, `whiteLost` INTEGER, `blackLost` INTEGER, `whiteGoesFirst` INTEGER, `moves` TEXT, `removedStones` TEXT, `phase` TEXT, `komi` REAL, `ended` INTEGER, `freeHandicapPlacement` INTEGER, `handicap` INTEGER, `undoRequested` INTEGER, `scoreAGAHandicap` INTEGER, `scoreHandicap` INTEGER, `scorePasses` INTEGER, `scorePrisoners` INTEGER, `scoreStones` INTEGER, `scoreTerritory` INTEGER, `scoreTerritoryInSeki` INTEGER, `name` TEXT, `rules` TEXT, `ranked` INTEGER, `disableAnalysis` INTEGER, `pausedSince` INTEGER, `messagesCount` INTEGER, `initial_state_black` TEXT, `initial_state_white` TEXT, `white_handicap` INTEGER, `white_komi` REAL, `white_prisoners` INTEGER, `white_scoring_positions` TEXT, `white_stones` INTEGER, `white_territory` INTEGER, `white_total` REAL, `black_handicap` INTEGER, `black_komi` REAL, `black_prisoners` INTEGER, `black_scoring_positions` TEXT, `black_stones` INTEGER, `black_territory` INTEGER, `black_total` REAL, `white_id` INTEGER NOT NULL, `white_username` TEXT NOT NULL, `white_rating` REAL, `white_historicRating` REAL, `white_country` TEXT, `white_icon` TEXT, `white_acceptedStones` TEXT, `white_ui_class` TEXT, `white_deviation` REAL, `black_id` INTEGER NOT NULL, `black_username` TEXT NOT NULL, `black_rating` REAL, `black_historicRating` REAL, `black_country` TEXT, `black_icon` TEXT, `black_acceptedStones` TEXT, `black_ui_class` TEXT, `black_deviation` REAL, `lastMove` INTEGER, `expiration` INTEGER, `now` INTEGER, `receivedAt` INTEGER, `whiteTimeSimple` INTEGER, `blackTimeSimple` INTEGER, `newPausedSince` INTEGER, `newPausedState` INTEGER, `startMode` INTEGER, `white_thinking_time` REAL, `white_skip_bonus` INTEGER, `white_block_time` REAL, `white_periods` INTEGER, `white_period_time` REAL, `white_moves_left` INTEGER, `black_thinking_time` REAL, `black_skip_bonus` INTEGER, `black_block_time` REAL, `black_periods` INTEGER, `black_period_time` REAL, `black_moves_left` INTEGER, `initial_state_system` TEXT, `initial_state_pause_on_weekends` INTEGER, `initial_state_time_control` TEXT, `initial_state_initial_time` INTEGER, `initial_state_max_time` INTEGER, `initial_state_time_increment` INTEGER, `initial_state_speed` TEXT, `initial_state_per_move` INTEGER, `initial_state_main_time` INTEGER, `initial_state_periods` INTEGER, `initial_state_period_time` INTEGER, `initial_state_stones_per_period` INTEGER, `initial_state_total_time` INTEGER, `pause_vacationWhite` INTEGER, `pause_vacationBlack` INTEGER, `pause_weekend` INTEGER, `pause_stoneRemoval` INTEGER, `pause_server` INTEGER, `pause_moderator` INTEGER, `pause_pausedByThirdParty` INTEGER, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -327,6 +327,12 @@
             "notNull": false
           },
           {
+            "fieldPath": "whitePlayer.deviation",
+            "columnName": "white_deviation",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
             "fieldPath": "blackPlayer.id",
             "columnName": "black_id",
             "affinity": "INTEGER",
@@ -372,6 +378,12 @@
             "fieldPath": "blackPlayer.ui_class",
             "columnName": "black_ui_class",
             "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "blackPlayer.deviation",
+            "columnName": "black_deviation",
+            "affinity": "REAL",
             "notNull": false
           },
           {
@@ -700,7 +712,7 @@
       },
       {
         "tableName": "Challenge",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `challenger_id` INTEGER, `challenger_username` TEXT, `challenger_rating` REAL, `challenger_historicRating` REAL, `challenger_country` TEXT, `challenger_icon` TEXT, `challenger_acceptedStones` TEXT, `challenger_ui_class` TEXT, `challenged_id` INTEGER, `challenged_username` TEXT, `challenged_rating` REAL, `challenged_historicRating` REAL, `challenged_country` TEXT, `challenged_icon` TEXT, `challenged_acceptedStones` TEXT, `challenged_ui_class` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `challenger_id` INTEGER, `challenger_username` TEXT, `challenger_rating` REAL, `challenger_historicRating` REAL, `challenger_country` TEXT, `challenger_icon` TEXT, `challenger_acceptedStones` TEXT, `challenger_ui_class` TEXT, `challenger_deviation` REAL, `challenged_id` INTEGER, `challenged_username` TEXT, `challenged_rating` REAL, `challenged_historicRating` REAL, `challenged_country` TEXT, `challenged_icon` TEXT, `challenged_acceptedStones` TEXT, `challenged_ui_class` TEXT, `challenged_deviation` REAL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -757,6 +769,12 @@
             "notNull": false
           },
           {
+            "fieldPath": "challenger.deviation",
+            "columnName": "challenger_deviation",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
             "fieldPath": "challenged.id",
             "columnName": "challenged_id",
             "affinity": "INTEGER",
@@ -802,6 +820,12 @@
             "fieldPath": "challenged.ui_class",
             "columnName": "challenged_ui_class",
             "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "challenged.deviation",
+            "columnName": "challenged_deviation",
+            "affinity": "REAL",
             "notNull": false
           }
         ],
@@ -1022,7 +1046,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '41f6abdc35160a31be9309553c5cdbd5')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '008c05148fea65140819152f75476c79')"
     ]
   }
 }

--- a/app/src/main/java/io/zenandroid/onlinego/data/model/local/Game.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/data/model/local/Game.kt
@@ -99,6 +99,14 @@ data class Game(
             val players = game.json?.players ?: game.gamedata?.players ?: game.players
             val gamedata = game.json ?: game.gamedata
 
+            val whiteDeviation = ((((game.white as? Map<*, *>)?.get("ratings") as? Map<*, *>)?.get("overall") as? Map<*, *>)?.get("deviation") as? Double)
+                ?: game.gamedata?.players?.white?.ratings?.overall?.deviation
+                ?: game.players?.white?.ratings?.overall?.deviation
+
+            val blackDeviation = ((((game.black as? Map<*, *>)?.get("ratings") as? Map<*, *>)?.get("overall") as? Map<*, *>)?.get("deviation") as? Double)
+                ?: game.gamedata?.players?.black?.ratings?.overall?.deviation
+                ?: game.players?.black?.ratings?.overall?.deviation
+
             val whitePlayer = Player(
                 id = (players?.white?.id ?: game.whiteId)!!,
                 username = players?.white?.username ?: (game.white as? Map<*,*>)?.get("username").toString(),
@@ -108,6 +116,7 @@ data class Game(
                 acceptedStones = players?.white?.accepted_stones,
                 ui_class = players?.white?.ui_class,
                 historicRating = game.historical_ratings?.white?.ratings?.overall?.rating,
+                deviation = whiteDeviation
             )
             val blackPlayer = Player(
                 id = (players?.black?.id ?: game.blackId)!!,
@@ -118,6 +127,7 @@ data class Game(
                 acceptedStones = players?.black?.accepted_stones,
                 ui_class = players?.black?.ui_class,
                 historicRating = game.historical_ratings?.black?.ratings?.overall?.rating,
+                deviation = blackDeviation
             )
 
             val isRanked : Boolean? = when(gamedata?.ranked) {
@@ -227,8 +237,8 @@ data class Game(
                 removedStones = "",
                 whiteScore = Score(komi = 5.5f, prisoners = 3),
                 blackScore = Score(prisoners = 1),
-                whitePlayer = Player(id = 1L, username = "Bula", rating = 1500.5, country = "UK", icon = null, acceptedStones = null, ui_class = null, historicRating = 1550.0),
-                blackPlayer = Player(id = 0L, username = "Playa", rating = 1600.5, country = "UK", icon = null, acceptedStones = null, ui_class = null, historicRating = 1550.0),
+                whitePlayer = Player(id = 1L, username = "Bula", rating = 1500.5, country = "UK", icon = null, acceptedStones = null, ui_class = null, historicRating = 1550.0, deviation = 50.0),
+                blackPlayer = Player(id = 0L, username = "Playa", rating = 1600.5, country = "UK", icon = null, acceptedStones = null, ui_class = null, historicRating = 1550.0, deviation = 50.0),
                 clock = Clock(lastMove = 120L, receivedAt = 120L, whiteTime = null, whiteTimeSimple = null, startMode = false, blackTime = null, blackTimeSimple = null),
                 phase = null,
                 komi = 5.5f,

--- a/app/src/main/java/io/zenandroid/onlinego/data/model/local/Player.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/data/model/local/Player.kt
@@ -14,7 +14,8 @@ data class Player(
     val country: String?,
     val icon: String?,
     val acceptedStones: String?,
-    val ui_class: String?
+    val ui_class: String?,
+    val deviation: Double?,
 ) {
     companion object {
         fun fromOGSPlayer(ogsPlayer: OGSPlayer) =
@@ -26,7 +27,8 @@ data class Player(
                         country = ogsPlayer.country,
                         icon = ogsPlayer.icon,
                         acceptedStones = ogsPlayer.accepted_stones,
-                        ui_class = ogsPlayer.ui_class
+                        ui_class = ogsPlayer.ui_class,
+                        deviation = ogsPlayer.ratings?.overall?.deviation,
                 )
     }
 }

--- a/app/src/main/java/io/zenandroid/onlinego/ui/screens/game/GameViewModel.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/screens/game/GameViewModel.kt
@@ -372,7 +372,7 @@ class GameViewModel(
             details += buildAnnotatedString {
                 append("\nYour rating is now ")
                 pushStyle(SpanStyle(fontWeight = FontWeight.Bold))
-                append(formatRank(egfToRank(you.rating)))
+                append(formatRank(egfToRank(you.rating), you.deviation))
                 pop()
                 append(" - ${String.format("%.0f", you.rating)} (")
                 if(you.rating != historicRating) {
@@ -514,7 +514,7 @@ class GameViewModel(
         return PlayerData(
             name = username,
             details = if(score != 0f) "${if(score > 0) "+ " else ""}$score points" else "",
-            rank = if(settingsRepository.showRanks) formatRank(egfToRank(rating)) else "",
+            rank = if(settingsRepository.showRanks) formatRank(egfToRank(rating), deviation) else "",
             flagCode = convertCountryCodeToEmojiFlag(country),
             iconURL = icon,
             color = color,

--- a/app/src/main/java/io/zenandroid/onlinego/ui/screens/game/composables/PlayerDetailsDialog.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/screens/game/composables/PlayerDetailsDialog.kt
@@ -75,7 +75,7 @@ fun PlayerDetailsDialog(
                 modifier = Modifier.padding(top = 14.dp, bottom = 8.dp)
             )
 
-            val rank = formatRank(egfToRank(player.rating), true)
+            val rank = formatRank(egfToRank(player.rating), player.deviation, true)
             val rating = player.rating?.toInt()?.toString() ?: ""
 
             Text(
@@ -86,7 +86,7 @@ fun PlayerDetailsDialog(
             )
 
             stats?.highestRating?.let { highestRatingFloat ->
-                val highestRank = formatRank(egfToRank(highestRatingFloat.toDouble()), true)
+                val highestRank = formatRank(egfToRank(highestRatingFloat.toDouble()), longFormat = true)
                 val highestRating = highestRatingFloat.toInt().toString()
                 StatsRow(title = "Highest rank", value = "$highestRank ($highestRating)")
             }
@@ -194,7 +194,8 @@ fun PreviewPlayerDetailsDialog() {
                     country = "UK",
                     icon = null,
                     acceptedStones = null,
-                    ui_class = null
+                    ui_class = null,
+                    deviation = null
                 ),
                 stats = UserStats(
                     highestRating = 1512.0f,

--- a/app/src/main/java/io/zenandroid/onlinego/ui/screens/mygames/MyGamesUI.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/screens/mygames/MyGamesUI.kt
@@ -155,6 +155,7 @@ private fun Preview() {
                             icon = null,
                             ui_class = null,
                             historicRating = null,
+                            deviation = null
                         ),
                         challenged = Player(
                             id = 1L,
@@ -165,6 +166,7 @@ private fun Preview() {
                             icon = null,
                             ui_class = null,
                             historicRating = null,
+                            deviation = null
                             )
                     ),
                     Challenge(
@@ -178,6 +180,7 @@ private fun Preview() {
                             icon = null,
                             ui_class = null,
                             historicRating = null,
+                            deviation = null,
                             ),
                         challenged = Player(
                             id = 0L,
@@ -188,6 +191,7 @@ private fun Preview() {
                             icon = null,
                             ui_class = null,
                             historicRating = null,
+                            deviation = null
                             )
                     ),
                 ),

--- a/app/src/main/java/io/zenandroid/onlinego/ui/screens/mygames/composables/ChallengeItem.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/screens/mygames/composables/ChallengeItem.kt
@@ -95,6 +95,7 @@ private fun Preview() {
                     icon = null,
                     ui_class = null,
                     historicRating = null,
+                    deviation = null,
                     ),
                 challenged = Player(
                     id = 1L,
@@ -105,6 +106,7 @@ private fun Preview() {
                     icon = null,
                     ui_class = null,
                     historicRating = null,
+                    deviation = null
                     )
             ),
             userId = 0L,
@@ -129,6 +131,7 @@ private fun Preview1() {
                     icon = null,
                     ui_class = null,
                     historicRating = null,
+                    deviation = null,
                     ),
                 challenged = Player(
                     id = 0L,
@@ -139,6 +142,7 @@ private fun Preview1() {
                     icon = null,
                     ui_class = null,
                     historicRating = null,
+                    deviation = null,
                     )
             ),
             userId = 0L,

--- a/app/src/main/java/io/zenandroid/onlinego/ui/screens/newchallenge/NewChallengeBottomSheet.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/screens/newchallenge/NewChallengeBottomSheet.kt
@@ -45,7 +45,7 @@ class NewChallengeBottomSheet : BottomSheetDialogFragment() {
             botView.apply {
                 name = "Opponent"
                 value = challenge.opponent?.let {
-                    "${it.username} (${formatRank(egfToRank(it.ratings?.overall?.rating))})"
+                    "${it.username} (${formatRank(egfToRank(it.ratings?.overall?.rating), it.ratings?.overall?.deviation)})"
                 } ?: "[Open Offer]"
                 setOnClickListener {
                     fragmentManager?.let {
@@ -148,7 +148,7 @@ class NewChallengeBottomSheet : BottomSheetDialogFragment() {
 
     private fun selectOpponent(opponent: Player?) {
         binding.botView.value = opponent
-                ?.let {"${it.username} (${formatRank(egfToRank(it.rating))})"}
+                ?.let {"${it.username} (${formatRank(egfToRank(it.rating), it.deviation)})"}
                 ?: "[Open Offer]"
         this.opponent = opponent
     }

--- a/app/src/main/java/io/zenandroid/onlinego/ui/screens/newchallenge/selectopponent/OpponentItem.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/screens/newchallenge/selectopponent/OpponentItem.kt
@@ -24,7 +24,7 @@ class OpponentItem(
 ) : BindableItem<ItemOpponentBinding>(opponent.id) {
     override fun bind(binding: ItemOpponentBinding, position: Int) {
         binding.nameView.text = opponent.username
-        binding.extraInfoView.text = formatRank(egfToRank(opponent.rating))
+        binding.extraInfoView.text = formatRank(egfToRank(opponent.rating), opponent.deviation)
         Glide.with(binding.iconView)
                 .load(processGravatarURL(opponent.icon, 40.DP()))
                 .listener(object: RequestListener<Drawable> {

--- a/app/src/main/java/io/zenandroid/onlinego/ui/screens/stats/StatsFragment.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/screens/stats/StatsFragment.kt
@@ -116,7 +116,7 @@ class StatsFragment : Fragment(), StatsContract.View {
 
             val glicko = playerDetails.ratings?.overall?.rating?.toInt()
             val deviation = playerDetails.ratings?.overall?.deviation?.toInt()
-            rankView.text = formatRank(egfToRank(playerDetails.ratings?.overall?.rating))
+            rankView.text = formatRank(egfToRank(playerDetails.ratings?.overall?.rating), playerDetails.ratings?.overall?.deviation)
             glickoView.text = "$glicko ± $deviation"
         }
     }
@@ -124,7 +124,7 @@ class StatsFragment : Fragment(), StatsContract.View {
     override fun mostFacedOpponent(playerDetails: OGSPlayer, total: Int, won: Int) {
         binding.apply {
             mostFacedOpponentView.text = playerDetails.username
-            opponentRankView.text = "(${formatRank(egfToRank(playerDetails.ratings?.overall?.rating))})"
+            opponentRankView.text = "(${formatRank(egfToRank(playerDetails.ratings?.overall?.rating), playerDetails.ratings?.overall?.deviation)})"
             playerDetails.icon?.let {
                 Glide.with(this@StatsFragment)
                         .load(processGravatarURL(it, opponentIconView.width))
@@ -139,7 +139,7 @@ class StatsFragment : Fragment(), StatsContract.View {
 
     override fun fillHighestWin(playerDetails: OGSPlayer, winningGame: Glicko2HistoryItem) {
         binding.apply {
-            val rank = formatRank(egfToRank(playerDetails.ratings?.overall?.rating))
+            val rank = formatRank(egfToRank(playerDetails.ratings?.overall?.rating), playerDetails.ratings?.overall?.rating)
 
             highestWinOpponent.text = playerDetails.username
             highestWinRank.text = "($rank)"
@@ -213,7 +213,7 @@ class StatsFragment : Fragment(), StatsContract.View {
                         onNothingSelected()
                     } else {
                         binding.chartDetails.text = SpannableStringBuilder()
-                            .bold { append("${e?.y?.toInt()} ELO (${formatRank(egfToRank(e.y.toDouble()), true)})") }
+                            .bold { append("${e?.y?.toInt()} ELO (${formatRank(egfToRank(e.y.toDouble()), longFormat = true)})") }
                             .append(" on ${formatDate(e.x.toLong())}")
                     }
                 }

--- a/app/src/main/java/io/zenandroid/onlinego/ui/views/PlayerDetailsView.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/views/PlayerDetailsView.kt
@@ -45,7 +45,7 @@ class PlayerDetailsView : FrameLayout {
                 return
             }
             binding.nameView.text = value?.username
-            binding.rankView.text = if (settingsRepository.showRanks) formatRank(egfToRank(value?.rating)) else ""
+            binding.rankView.text = if (settingsRepository.showRanks) formatRank(egfToRank(value?.rating), value?.deviation) else ""
             value?.country?.let {
                 binding.flagView.text = convertCountryCodeToEmojiFlag(it)
             }

--- a/app/src/main/java/io/zenandroid/onlinego/utils/Globals.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/utils/Globals.kt
@@ -16,6 +16,8 @@ import java.util.regex.Pattern
 import kotlin.math.*
 
 val PERCENTILES = arrayOf(0, 477, 550, 600, 640, 671, 701, 725, 754, 774, 794, 815, 829, 847, 866, 881, 896, 912, 924, 940, 952, 969, 982, 994, 1007, 1016, 1029, 1043, 1056, 1066, 1080, 1089, 1098, 1113, 1122, 1137, 1147, 1157, 1167, 1182, 1192, 1203, 1213, 1224, 1234, 1245, 1256, 1267, 1278, 1289, 1300, 1311, 1323, 1334, 1346, 1357, 1369, 1381, 1387, 1399, 1411, 1424, 1436, 1448, 1461, 1474, 1486, 1499, 1512, 1525, 1539, 1552, 1565, 1579, 1593, 1607, 1621, 1635, 1649, 1670, 1685, 1699, 1714, 1729, 1752, 1767, 1790, 1805, 1829, 1845, 1869, 1893, 1918, 1943, 1968, 2003, 2038, 2091, 2146, 2241)
+// same value used by the web client in OGS
+const val PROVISIONAL_CUT_POINT: Double = 160.0;
 
 fun getPercentile(rating: Double): Int {
     PERCENTILES.forEachIndexed { index, i -> if(rating < i) return index-1 }
@@ -57,9 +59,8 @@ fun egfToRank(rating: Double?) =
 
 fun formatRank(rank: Double?, deviation: Double? = 0.0, longFormat: Boolean = false): String {
     deviation?.let {
-        Log.d("deviation test", it.toString())
         when {
-            it >= 160.0 -> return "?"
+            it >= PROVISIONAL_CUT_POINT -> return "?"
             else -> {}
         }
     }

--- a/app/src/main/java/io/zenandroid/onlinego/utils/Globals.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/utils/Globals.kt
@@ -55,13 +55,21 @@ fun egfToRank(rating: Double?) =
             ln(it.coerceIn(MIN_RATING, MAX_RATING) / 525) * 23.15
         }
 
-fun formatRank(rank: Double?, longFormat: Boolean = false) =
-        when(rank) {
-            null -> "?"
-            in 30f .. 100f -> "${floor(rank - 29).toInt()}${if(longFormat) " dan" else "d"}"
-            in 0f .. 30f -> "${ceil(30 - rank).toInt()}${if (longFormat) " kyu" else "k"}"
-            else -> ""
+fun formatRank(rank: Double?, deviation: Double? = 0.0, longFormat: Boolean = false): String {
+    deviation?.let {
+        Log.d("deviation test", it.toString())
+        when {
+            it >= 160.0 -> return "?"
+            else -> {}
         }
+    }
+    return when(rank) {
+        null -> "?"
+        in 30f .. 100f -> "${floor(rank - 29).toInt()}${if(longFormat) " dan" else "d"}"
+        in 0f .. 30f -> "${ceil(30 - rank).toInt()}${if (longFormat) " kyu" else "k"}"
+        else -> ""
+    }
+}
 
 private val gravatarRegex = Pattern.compile("(.*gravatar.com/avatar/[0-9a-fA-F]*+).*")
 private val rackcdnRegex = Pattern.compile("(.*rackcdn.com.*)-\\d*\\.png")


### PR DESCRIPTION
I have been using the client for a while and noticed this behavior that is inconsistent with the web client and decided to try to fix it. I checked and apparently the cause is, it assumes that the condition to print the interrogation sign is when the rating is null, which never is. The web client instead, uses the deviation in the rating and a cutoff point to decide that in the moment is lesser than that, then it has a official rank.