### PR TITLE
Add LGBT and other special flags

### DIFF
--- a/app/src/main/java/io/zenandroid/onlinego/utils/Globals.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/utils/Globals.kt
@@ -93,6 +93,18 @@ fun processGravatarURL(url: String?, width: Int): String? {
 
 private val SPECIAL_FLAGS = mapOf(
     "_LGBT" to "\uD83C\uDFF3\uFE0F\u200D\uD83C\uDF08",
+
+    // These have two letter iso codes, but OGS uses a custom identifier
+    "_European_Union" to "\uD83C\uDDEA\uD83C\uDDFA",
+    "_Kosovo" to "\uD83C\uDDFD\uD83C\uDDF0",
+
+    // RGI subdivisions
+    "_England" to "\uD83C\uDFF4\uDB40\uDC67\uDB40\uDC62\uDB40\uDC65\uDB40\uDC6E\uDB40\uDC67\uDB40\uDC7F",
+    "_Scotland" to "\uD83C\uDFF4\uDB40\uDC67\uDB40\uDC62\uDB40\uDC73\uDB40\uDC63\uDB40\uDC74\uDB40\uDC7F",
+    "_Wales" to "\uD83C\uDFF4\uDB40\uDC67\uDB40\uDC62\uDB40\uDC77\uDB40\uDC6C\uDB40\uDC73\uDB40\uDC7F",
+
+    // Just for fun
+    "_Pirate" to "\uD83C\uDFF4\u200D\u2620\uFE0F",
 )
 
 fun convertCountryCodeToEmojiFlag(country: String?): String {

--- a/app/src/main/java/io/zenandroid/onlinego/utils/Globals.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/utils/Globals.kt
@@ -91,7 +91,13 @@ fun processGravatarURL(url: String?, width: Int): String? {
     return url
 }
 
+private val SPECIAL_FLAGS = mapOf(
+    "_LGBT" to "\uD83C\uDFF3\uFE0F\u200D\uD83C\uDF08",
+)
+
 fun convertCountryCodeToEmojiFlag(country: String?): String {
+    SPECIAL_FLAGS[country]?.let { return it }
+
     if(country == null || country.length != 2 || "un" == country) {
         return "\uD83C\uDDFA\uD83C\uDDF3"
     }


### PR DESCRIPTION
Fixes #149 

First real PR!  Here's how it looks:

<img width="226" alt="Screen Shot 2023-02-15 at 9 02 07 AM" src="https://user-images.githubusercontent.com/25233703/218922504-02285799-6675-4ec5-83e2-00d74a0350c7.png">
<img width="288" alt="Screen Shot 2023-02-15 at 12 35 22 PM" src="https://user-images.githubusercontent.com/25233703/218922440-2061d21b-167a-4cea-9f0e-5cbc686527f5.png">

Note: The `SPECIAL_FLAGS` map may seem unnecessary with only one element, but I figured it is more extensible in the long run.  There are more flags that don't correspond to a two-letter iso code, but are supported by both OGS and Unicode (🏴󠁧󠁢󠁥󠁮󠁧󠁿, 🏴‍☠️, 🇪🇺 etc.)
