### PR TITLE
Added missing error handling to middlewares

### DIFF
--- a/app/src/main/java/io/zenandroid/onlinego/mvi/Store.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/mvi/Store.kt
@@ -28,14 +28,14 @@ class Store<S: Any, A: Any> (
         }
             .distinctUntilChanged()
             .doOnError(this::onError)
-            .onErrorResumeNext(Observable.empty()) // BUG! this completes the observable
+            .onErrorResumeNext(Observable.empty()) // this completes the observable, so reducers have to handle all the errors themselves
             .subscribe(state::accept)
 
         disposable += Observable.merge<A>(
             middlewares.map { it.bind(actions, state) }
         )
                 .doOnError(this::onError)
-                .onErrorResumeNext(Observable.empty()) // BUG! this completes the observable
+                .onErrorResumeNext(Observable.empty()) // this completes the observable, so middlewares have to handle all the errors themselves
                 .subscribe(actions::accept)
 
         return disposable

--- a/app/src/main/java/io/zenandroid/onlinego/ui/screens/localai/middlewares/HintMiddleware.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/screens/localai/middlewares/HintMiddleware.kt
@@ -1,5 +1,6 @@
 package io.zenandroid.onlinego.ui.screens.localai.middlewares
 
+import android.util.Log
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.withLatestFrom
 import io.zenandroid.onlinego.ai.KataGoAnalysisEngine
@@ -8,20 +9,30 @@ import io.zenandroid.onlinego.ui.screens.localai.AiGameAction
 import io.zenandroid.onlinego.ui.screens.localai.AiGameAction.AIHint
 import io.zenandroid.onlinego.ui.screens.localai.AiGameAction.UserAskedForHint
 import io.zenandroid.onlinego.ui.screens.localai.AiGameState
+import io.zenandroid.onlinego.utils.recordException
 
 class HintMiddleware : Middleware<AiGameState, AiGameAction> {
     override fun bind(actions: Observable<AiGameAction>, state: Observable<AiGameState>): Observable<AiGameAction> {
         return actions.ofType(UserAskedForHint::class.java)
                 .withLatestFrom(state)
                 .filter{ (_, state) -> state.engineStarted && state.position != null}
-                .flatMapSingle { (_, state) ->
+                .flatMap { (_, state) ->
                     KataGoAnalysisEngine.analyzeMoveSequence(
                             sequence = state.history,
                             maxVisits = 30,
                             komi = state.position?.komi ?: 0f,
                             includeOwnership = false
-                    ).map(::AIHint)
+                    )
+                            .map(::AIHint)
+                            .toObservable()
+                            .doOnError(this::onError)
+                            .onErrorResumeNext(Observable.empty())
                 }
 
+    }
+
+    private fun onError(throwable: Throwable) {
+        Log.e("HintMiddleware", throwable.message, throwable)
+        recordException(throwable)
     }
 }

--- a/app/src/main/java/io/zenandroid/onlinego/ui/screens/newchallenge/selectopponent/searchplayer/SearchMiddleware.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/screens/newchallenge/selectopponent/searchplayer/SearchMiddleware.kt
@@ -1,26 +1,34 @@
 package io.zenandroid.onlinego.ui.screens.newchallenge.selectopponent.searchplayer
 
+import android.util.Log
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
-import io.zenandroid.onlinego.mvi.Middleware
 import io.zenandroid.onlinego.data.repositories.PlayersRepository
-import org.koin.core.context.GlobalContext.get
+import io.zenandroid.onlinego.mvi.Middleware
+import io.zenandroid.onlinego.utils.recordException
 
 class SearchMiddleware(
         private val playersRepository: PlayersRepository
 ) : Middleware<SearchPlayerState, SearchPlayerAction> {
 
     override fun bind(
-        actions: Observable<SearchPlayerAction>,
-        state: Observable<SearchPlayerState>
+            actions: Observable<SearchPlayerAction>,
+            state: Observable<SearchPlayerState>
     ): Observable<SearchPlayerAction> =
-        actions.ofType(SearchPlayerAction.Search::class.java)
-                .filter { it.query.isNotBlank() }
-                .flatMap { action ->
-                    playersRepository.searchPlayers(action.query)
-                            .subscribeOn(Schedulers.io())
-                            .map<SearchPlayerAction> { SearchPlayerAction.Results(action.query, it) }
-                            .toObservable()
-                            .startWith( SearchPlayerAction.SearchStarted )
-                }
+            actions.ofType(SearchPlayerAction.Search::class.java)
+                    .filter { it.query.isNotBlank() }
+                    .flatMap { action ->
+                        playersRepository.searchPlayers(action.query)
+                                .subscribeOn(Schedulers.io())
+                                .map<SearchPlayerAction> { SearchPlayerAction.Results(action.query, it) }
+                                .toObservable()
+                                .startWith(SearchPlayerAction.SearchStarted)
+                                .doOnError(this::onError)
+                                .onErrorResumeNext(Observable.empty())
+                    }
+
+    private fun onError(throwable: Throwable) {
+        Log.e("SearchMiddleware", throwable.message, throwable)
+        recordException(throwable)
+    }
 }


### PR DESCRIPTION
Observables from `Middleware`s are merged [here](https://github.com/acristescu/OnlineGo/blob/ea1edbb7e178f0646392dab3135932bf9deb388b/app/src/main/java/io/zenandroid/onlinego/mvi/Store.kt#L34-L36) in `Store` class.

If any of these observables throw an error, the whole combined observable stops working and accepting events from `Middleware`s. It is commented as bug [here](https://github.com/acristescu/OnlineGo/blob/ea1edbb7e178f0646392dab3135932bf9deb388b/app/src/main/java/io/zenandroid/onlinego/mvi/Store.kt#L38) but it is an intented behavior of RxJava `Observable`, because errors are supposed to finish the observable.

Therefore, if one of the `Middleware`s in a `Store` throws an error, the `Store` will stop accepting events from all of its `Middleware`s. To prevent this, all `Middleware`s have to handle all possible errors themselves and provide error-free observables to `Store`.

In this pull request, I went over `Middleware`s and added error handling in those that can potentially throw errors.