### PR TITLE
Keep screen on and disable screen saver while playing a game (WAKE_LOCK, FLAG_KEEP_SCREEN_ON)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/io/zenandroid/onlinego/ui/screens/game/GameFragment.kt
+++ b/app/src/main/java/io/zenandroid/onlinego/ui/screens/game/GameFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
@@ -95,5 +96,13 @@ class GameFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         analyticsReportScreen("Game")
+    }
+    override fun onStart() {
+        super.onStart()
+        getActivity()?.getWindow()?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    }
+    override fun onStop() {
+        super.onStop()
+        getActivity()?.getWindow()?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
 }


### PR DESCRIPTION
I enjoy this app a lot!
Recently, I noticed (when playing correspondence games), that the screen will turn black, so I was wondering, if we should disable the screen saver, during a game.

(I'm not an android developer, but it looks like specifying the WAKE_LOCK permission and setting the KEEP_SCREEN_ON flag might be enough)

in this PR, I'm trying to set the KEEP_SCREEN_ON flag programmatically, but it might be better to set it in the layout like described here:
https://developer.android.com/develop/background-work/background-tasks/scheduling/wakelock#screen